### PR TITLE
NFT royalties

### DIFF
--- a/akita_inu_asa_utils.py
+++ b/akita_inu_asa_utils.py
@@ -55,7 +55,11 @@ def compile_program(client, source_code, file_path=None):
     else:
         check_build_dir()
         dump(base64.b64decode(compile_response['result']), 'build/' + file_path)
-    return compile_response["hash"]
+
+
+def get_program_hash(client, source_code):
+    compile_response = client.compile(source_code)
+    return compile_response['hash']
 
 
 # read user local state
@@ -176,7 +180,7 @@ def create_app_signed_txn(private_key,
                           global_schema,
                           local_schema,
                           app_args,
-                          **kwargs):
+                          asset_ids=None):
     """
         Creates an signed "create app" transaction to an application
             Args:
@@ -199,7 +203,7 @@ def create_app_signed_txn(private_key,
                                                     global_schema,
                                                     local_schema,
                                                     app_args,
-                                                    **kwargs)
+                                                    foreign_assets=asset_ids)
     signed_txn = sign_txn(unsigned_txn, private_key)
     return signed_txn, signed_txn.transaction.get_txid()
 

--- a/akita_inu_asa_utils.py
+++ b/akita_inu_asa_utils.py
@@ -175,7 +175,8 @@ def create_app_signed_txn(private_key,
                           clear_program,
                           global_schema,
                           local_schema,
-                          app_args):
+                          app_args,
+                          **kwargs):
     """
         Creates an signed "create app" transaction to an application
             Args:
@@ -197,7 +198,8 @@ def create_app_signed_txn(private_key,
                                                     clear_program,
                                                     global_schema,
                                                     local_schema,
-                                                    app_args)
+                                                    app_args,
+                                                    **kwargs)
     signed_txn = sign_txn(unsigned_txn, private_key)
     return signed_txn, signed_txn.transaction.get_txid()
 

--- a/akita_inu_asa_utils.py
+++ b/akita_inu_asa_utils.py
@@ -9,6 +9,10 @@ import os
 import base64
 
 
+def zero_address():
+    return encoding.encode_address(bytes(32))
+
+
 def get_application_address(app_id):
     return encoding.encode_address(encoding.checksum(b'appID' + app_id.to_bytes(8, 'big')))
 
@@ -51,6 +55,7 @@ def compile_program(client, source_code, file_path=None):
     else:
         check_build_dir()
         dump(base64.b64decode(compile_response['result']), 'build/' + file_path)
+    return compile_response["hash"]
 
 
 # read user local state

--- a/contracts/nft_royalties/deployment.py
+++ b/contracts/nft_royalties/deployment.py
@@ -24,7 +24,7 @@ def deploy_app(client, private_key, asset_id, approval_program, clear_program, g
                                               global_schema,
                                               local_schema,
                                               app_args,
-                                              foreign_assets=[asset_id])
+                                              asset_ids=[asset_id])
 
     # send transaction
     client.send_transactions([signed_txn])

--- a/contracts/nft_royalties/deployment.py
+++ b/contracts/nft_royalties/deployment.py
@@ -1,0 +1,81 @@
+from .program import compile_transfer_app, compile_escrow_app
+from algosdk.future import transaction
+from algosdk import account, mnemonic, logic, encoding
+from akita_inu_asa_utils import *
+from pyteal import *
+
+
+def deploy_app(client, private_key, approval_program, clear_program, global_schema, local_schema, app_args):
+    # define sender as creator
+    public_key = account.address_from_private_key(private_key)
+
+    # declare on_complete as NoOp
+    on_complete = transaction.OnComplete.NoOpOC.real
+
+    # get node suggested parameters
+    params = client.suggested_params()
+
+    signed_txn, tx_id = create_app_signed_txn(private_key,
+                                              public_key,
+                                              params,
+                                              on_complete,
+                                              approval_program,
+                                              clear_program,
+                                              global_schema,
+                                              local_schema,
+                                              app_args)
+
+    # send transaction
+    client.send_transactions([signed_txn])
+
+    wait_for_txn_confirmation(client, tx_id, 5)
+
+    # display results
+    transaction_response = client.pending_transaction_info(tx_id)
+    app_id = transaction_response['application-index']
+    print("Deployed new app-id: " + str(app_id))
+    print("Deployed application address: " +
+          encoding.encode_address(encoding.checksum(b'appID' + app_id.to_bytes(8, 'big'))))
+
+    return app_id
+
+
+# asset_id:         ASA's ID, hardcoded into transfer app
+# royalty_percent:  The minimum percent that must be paid in royalty while
+#                   while transferring our ASA
+# royalty_payouts:  List of dictionaries specifying payout addresses and ratios
+def deploy(algod_address, algod_token, creator_mnemonic, asset_id, royalty_percent, royalty_payouts):
+    private_key = mnemonic.to_private_key(creator_mnemonic)
+    public_key = account.address_from_private_key(private_key)
+    algod_client = get_algod_client(algod_token,
+                                    algod_address)
+
+    compile_transfer_app(algod_client, asset_id, royalty_percent, royalty_payouts)
+    print("Program Compiled")
+
+    approval_program = load_compiled(file_path='nft_royalties/transfer.compiled')
+    clear_program = load_compiled(file_path='nft_royalties/clear.compiled')
+
+    global_schema = load_schema(file_path='nft_royalties/globalSchema')
+    local_schema = load_schema(file_path='nft_royalties/localSchema')
+
+    app_args = []
+
+    transfer_app_id = deploy_app(algod_client,
+                        private_key,
+                        approval_program,
+                        clear_program,
+                        global_schema,
+                        local_schema,
+                        app_args)
+    escrow_hash = compile_escrow_app(algod_client, transfer_app_id)
+
+    txn = transaction.AssetConfigTxn(sender=public_key,
+                                     sp=algod_client.suggested_params(),
+                                     index=asset_id,
+                                     strict_empty_address_check=False,
+                                     clawback=escrow_hash)
+    signed_txn = txn.sign(private_key)
+    algod_client.send_transaction(signed_txn)
+
+    return (transfer_app_id, escrow_hash)

--- a/contracts/nft_royalties/program.py
+++ b/contracts/nft_royalties/program.py
@@ -1,15 +1,20 @@
+from akita_inu_asa_utils import *
 from pyteal import *
 
-def transfer_approval(royalty_percent, royalty_payouts):
+
+def transfer_approval(asset_id, royalty_percent, royalty_payouts):
     ratio_sum = sum([r["ratio"] for r in royalty_payouts])
 
     indices = range(len(royalty_payouts))
+
+    owner = Bytes("owner")
+    royalty = Bytes("royalty")
 
     default_frozen = AssetParam.defaultFrozen(Int(0))
     clawback = AssetParam.clawback(Int(0))
     manager = AssetParam.manager(Int(0))
     freeze = AssetParam.freeze(Int(0))
-    royalty_minimum = Gtxn[1].amount() / Int(royalty_percent) # might store in scratch?
+    royalty_minimum = Gtxn[1].amount() / App.globalGet(royalty) # might store in scratch?
 
     def payRoyalty(receiver):
         return Seq(
@@ -25,6 +30,12 @@ def transfer_approval(royalty_percent, royalty_payouts):
             ),
             InnerTxnBuilder.Submit(),
         )
+
+    on_create = Seq(
+        App.globalPut(owner, Txn.sender()),
+        App.globalPut(royalty, Int(int(100 / royalty_percent))),
+        Approve()
+    )
 
     # Gtxn[0]
     #     * Asset transfer via clawback, must be signed with escrow's
@@ -58,6 +69,7 @@ def transfer_approval(royalty_percent, royalty_payouts):
 
                 Gtxn[0].fee() == Int(0),
                 Gtxn[0].asset_amount() == Int(1),
+                Gtxn[0].xfer_asset() == Int(asset_id),
 
                 Gtxn[0].close_remainder_to() == Global.zero_address(),
                 Gtxn[0].rekey_to() == Global.zero_address(),
@@ -67,6 +79,8 @@ def transfer_approval(royalty_percent, royalty_payouts):
                 Gtxn[2].rekey_to() == Global.zero_address(),
                 Gtxn[3].close_remainder_to() == Global.zero_address(),
                 Gtxn[3].rekey_to() == Global.zero_address(),
+
+                Txn.sender() == Gtxn[0].asset_sender(),
 
                 default_frozen.hasValue(),
                 default_frozen.value(),
@@ -87,13 +101,19 @@ def transfer_approval(royalty_percent, royalty_payouts):
             )
         ),
         Seq(*[payRoyalty(royalty_payouts[i]) for i in indices]),
+        App.globalPut(owner, Gtxn[0].asset_receiver()),
         Approve()
     )
 
-    on_delete = Return(Txn.sender() == Global.creator_address())
+    on_delete = Return(
+        And(
+            Txn.sender() == Global.creator_address(),
+            Txn.sender() == App.globalGet(owner)
+        )
+    )
 
     program = Cond(
-        [Txn.application_id() == Int(0), Approve()],
+        [Txn.application_id() == Int(0), on_create],
         [Txn.on_completion() == OnComplete.NoOp, on_call],
         [Txn.on_completion() == OnComplete.DeleteApplication, on_delete],
         [Int(1), Reject()]
@@ -101,7 +121,7 @@ def transfer_approval(royalty_percent, royalty_payouts):
     return program
 
 
-def escrow_approval(transfer_app_id = 121):
+def escrow_approval(transfer_app_id=121):
     # Escrow contract/account
     on_call = Seq(
         Assert(
@@ -121,23 +141,38 @@ def escrow_approval(transfer_app_id = 121):
     return program
 
 
-if __name__ == "__main__":
-    royalty_percent = 10
-    royalty_payouts = [
-            {
-                "address": "ECNHJST6SMCFXH6R6Z2L4D4ZYHG6FZFULY7O3XFTXORWBRZJUF2MSQRGZA",
-                "ratio": 6
-            },
-            {
-                "address": "XFNIWS5CZ67DKPR5767PR3YIWDZFYSFNLPPEAE6YKFIMUUIZC7WGYK22IA",
-                "ratio": 4
-            },
-        ]
+def clear_program():
+    return Reject()
 
-    with open("escrow.teal", "w") as f:
-        compiled = compileTeal(escrow_approval(), mode=Mode.Application, version=5)
-        f.write(compiled)
 
-    with open("transfer_split.teal", "w") as f:
-        compiled = compileTeal(transfer_approval(royalty_percent, royalty_payouts), mode=Mode.Application, version=5)
-        f.write(compiled)
+def compile_transfer_app(algod_client, asset_id, royalty_percent, royalty_payouts):
+    check_build_dir()
+
+    if not os.path.exists('build/nft_royalties'):
+        os.mkdir('build/nft_royalties')
+
+    compile_program(
+            algod_client,
+            compileTeal(
+                transfer_approval(asset_id, royalty_percent, royalty_payouts),
+                mode=Mode.Application,
+                version=5),
+            'nft_royalties/transfer.compiled')
+    compile_program(
+            algod_client,
+            compileTeal(clear_program(), mode=Mode.Application, version=5),
+            'nft_royalties/clear.compiled')
+
+    write_schema("nft_royalties/globalSchema", 1, 1)
+    write_schema("nft_royalties/localSchema", 0, 0)
+
+
+def compile_escrow_app(algod_client, transfer_app_id):
+    teal = compileTeal(
+                escrow_approval(transfer_app_id),
+                mode=Mode.Signature,
+                version=5
+            )
+    with open("build/nft_royalties/escrow.teal", "w") as f:
+        f.write(teal)
+    return compile_program(algod_client, teal, "nft_royalties/escrow.compiled")

--- a/contracts/nft_royalties/program.py
+++ b/contracts/nft_royalties/program.py
@@ -285,4 +285,5 @@ def compile_escrow_app(algod_client, transfer_app_id):
             )
     with open('build/nft_royalties/escrow.teal', 'w') as f:
         f.write(teal)
-    return compile_program(algod_client, teal, 'nft_royalties/escrow.compiled')
+    compile_program(algod_client, teal, 'nft_royalties/escrow.compiled')
+    return get_program_hash(algod_client, teal)

--- a/contracts/nft_royalties/program.py
+++ b/contracts/nft_royalties/program.py
@@ -2,29 +2,45 @@ from akita_inu_asa_utils import *
 from pyteal import *
 
 
-def transfer_approval(asset_id, royalty_percent, royalty_payouts):
-    ratio_sum = sum([r["ratio"] for r in royalty_payouts])
+def transfer_approval(asset_id, app_manager_address, royalty_permille, royalty_payouts):
+    # app_manager_address: address that is allowed to execute privileged calls
+    #                      on this app
+    # royalty_permille:    royalty value in terms of permille of payment value
+    # royalty_payouts:     list of dictionaries, each including an address and
+    #                      the portion of the royalty paid to it
 
+    ratio_sum = sum([r['ratio'] for r in royalty_payouts])
     indices = range(len(royalty_payouts))
 
-    owner = Bytes("owner")
-    royalty = Bytes("royalty")
+    # app_manager: stores app_manager_address on creation, can't be updated
+    #              right now (may change this)
+    # owner:       the address holding our NFT, according to transfer history
+    # royalty:     stores royalty_permille on creation, can be updated via
+    #              'set_royalty' calls
+    app_manager = Bytes('app_manager')
+    owner = Bytes('owner')
+    royalty = Bytes('royalty')
 
+    # This is how we actually test for ownership, the owner global is mainly
+    # for convenience
+    sender_has_nft = AssetHolding.balance(Txn.sender(), Int(0))
     default_frozen = AssetParam.defaultFrozen(Int(0))
     clawback = AssetParam.clawback(Int(0))
     manager = AssetParam.manager(Int(0))
     freeze = AssetParam.freeze(Int(0))
-    royalty_minimum = Gtxn[1].amount() / App.globalGet(royalty) # might store in scratch?
+    royalty_minimum = Gtxn[1].amount() * App.globalGet(royalty) / Int(1000)
 
+    # This function statically generates an inner transaction given an
+    # item in royalty_payouts
     def payRoyalty(receiver):
         return Seq(
             InnerTxnBuilder.Begin(),
             InnerTxnBuilder.SetFields(
                 {
                     TxnField.type_enum: TxnType.Payment,
-                    TxnField.receiver: Addr(receiver["address"]),
+                    TxnField.receiver: Addr(receiver['address']),
                     TxnField.amount:
-                        royalty_minimum * Int(receiver["ratio"]) / Int(ratio_sum),
+                        royalty_minimum * Int(receiver['ratio']) / Int(ratio_sum),
                     TxnField.fee: Int(0),
                 }
             ),
@@ -32,11 +48,22 @@ def transfer_approval(asset_id, royalty_percent, royalty_payouts):
         )
 
     on_create = Seq(
-        App.globalPut(owner, Txn.sender()),
-        App.globalPut(royalty, Int(int(100 / royalty_percent))),
+        sender_has_nft,
+        Assert(
+            And(
+                Txn.assets.length() == Int(1),
+                sender_has_nft.value()
+            )
+        ),
+        App.globalPut(app_manager, Addr(app_manager_address)),
+        App.globalPut(owner, Addr(app_manager_address)),
+        App.globalPut(royalty, Int(royalty_permille)),
         Approve()
     )
 
+    #
+    # The main transfer logic
+    #
     # Gtxn[0]
     #     * Asset transfer via clawback, must be signed with escrow's
     #       code
@@ -54,13 +81,15 @@ def transfer_approval(asset_id, royalty_percent, royalty_payouts):
     #
     # Gtxn[3]
     #     * This call
-    on_call = Seq(
+    #
+    asset_transfer = Seq(
         default_frozen,
         clawback,
         manager,
         freeze,
         Assert(
             And(
+                Txn.assets.length() == Int(1),
                 Global.group_size() == Int(4),
                 Gtxn[0].type_enum() == TxnType.AssetTransfer,
                 Gtxn[1].type_enum() == TxnType.Payment,
@@ -85,8 +114,8 @@ def transfer_approval(asset_id, royalty_percent, royalty_payouts):
                 default_frozen.hasValue(),
                 default_frozen.value(),
                 clawback.value() != Global.zero_address(),
-                manager.value() == Global.zero_address(),
-                freeze.value() == Global.zero_address(),
+                manager.value() == clawback.value(),
+                freeze.value() == clawback.value(),
 
                 Gtxn[1].sender() == Gtxn[0].asset_receiver(),
                 Gtxn[0].asset_sender() == Gtxn[1].receiver(),
@@ -105,16 +134,86 @@ def transfer_approval(asset_id, royalty_percent, royalty_payouts):
         Approve()
     )
 
-    on_delete = Return(
-        And(
-            Txn.sender() == Global.creator_address(),
-            Txn.sender() == App.globalGet(owner)
+    new_royalty = Btoi(Txn.application_args[1])
+    set_royalty = Seq(
+        sender_has_nft,
+        Assert(
+            And(
+                Global.group_size() == Int(1),
+                Txn.sender() == App.globalGet(app_manager),
+                Or(
+                    # Only allow increasing royalty while holding the asset
+                    new_royalty < App.globalGet(royalty),
+                    sender_has_nft.value()
+                )
+            )
+        ),
+        App.globalPut(royalty, new_royalty),
+        Approve()
+    )
+
+    call = Txn.application_args[0]
+    on_call = Cond(
+        [call == Bytes('transfer'), asset_transfer],
+        [call == Bytes('set_royalty'), set_royalty],
+    )
+
+    on_update = Seq(
+        sender_has_nft,
+        Return(
+            And(
+                Global.group_size() == Int(1),
+                Txn.sender() == App.globalGet(app_manager),
+                sender_has_nft.value(),
+                Txn.rekey_to() == Global.zero_address()
+            )
         )
+    )
+
+    on_delete = Seq(
+        Assert(Txn.sender() == App.globalGet(app_manager)),
+        Assert(
+            # You can dump the remaining ALGO balance from the escrow (should
+            # be 0.1), or just leave it and destroy everything
+            Or(
+                And(
+                    Global.group_size() == Int(3),
+                    Gtxn[0].type_enum() == TxnType.AssetConfig,
+                    Gtxn[1].type_enum() == TxnType.Payment,
+                    Gtxn[2].type_enum() == TxnType.ApplicationCall,
+
+                    Gtxn[1].fee() == Int(0),
+                    Gtxn[1].close_remainder_to() == Txn.sender(),
+
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[1].rekey_to() == Global.zero_address(),
+                    Gtxn[2].rekey_to() == Global.zero_address()
+                ),
+                And(
+                    Global.group_size() == Int(2),
+                    Gtxn[0].type_enum() == TxnType.AssetConfig,
+                    Gtxn[1].type_enum() == TxnType.ApplicationCall,
+
+                    Gtxn[0].rekey_to() == Global.zero_address(),
+                    Gtxn[1].rekey_to() == Global.zero_address()
+                ),
+            )
+        ),
+        InnerTxnBuilder.Begin(),
+        InnerTxnBuilder.SetFields(
+            {
+                TxnField.type_enum: TxnType.Payment,
+                TxnField.close_remainder_to: Txn.sender(),
+            }
+        ),
+        InnerTxnBuilder.Submit(),
+        Approve()
     )
 
     program = Cond(
         [Txn.application_id() == Int(0), on_create],
         [Txn.on_completion() == OnComplete.NoOp, on_call],
+        [Txn.on_completion() == OnComplete.UpdateApplication, on_update],
         [Txn.on_completion() == OnComplete.DeleteApplication, on_delete],
         [Int(1), Reject()]
     )
@@ -123,20 +222,14 @@ def transfer_approval(asset_id, royalty_percent, royalty_payouts):
 
 def escrow_approval(transfer_app_id=121):
     # Escrow contract/account
-    on_call = Seq(
-        Assert(
-            And(
-                Txn.fee() == Int(0),
-                Gtxn[3].type_enum() == TxnType.ApplicationCall,
-                Gtxn[3].application_id() == Int(transfer_app_id),
-            ),
-        ),
-        Approve(),
-    )
+    app_txn_index = Global.group_size() - Int(1)
 
-    program = Cond(
-        [Txn.on_completion() == OnComplete.NoOp, on_call],
-        [Int(1), Reject()]
+    program = Return(
+        And(
+            Txn.fee() == Int(0),
+            Gtxn[app_txn_index].type_enum() == TxnType.ApplicationCall,
+            Gtxn[app_txn_index].application_id() == Int(transfer_app_id),
+        )
     )
     return program
 
@@ -145,26 +238,36 @@ def clear_program():
     return Reject()
 
 
-def compile_transfer_app(algod_client, asset_id, royalty_percent, royalty_payouts):
+def compile_transfer_app(algod_client,
+                         asset_id,
+                         app_manager_address,
+                         royalty_permille,
+                         royalty_payouts):
     check_build_dir()
 
     if not os.path.exists('build/nft_royalties'):
         os.mkdir('build/nft_royalties')
 
+    transfer_teal = compileTeal(
+            transfer_approval(asset_id,
+                              app_manager_address,
+                              royalty_permille,
+                              royalty_payouts),
+            mode=Mode.Application,
+            version=5)
+    with open('build/nft_royalties/transfer.teal', 'w') as f:
+        f.write(transfer_teal)
     compile_program(
             algod_client,
-            compileTeal(
-                transfer_approval(asset_id, royalty_percent, royalty_payouts),
-                mode=Mode.Application,
-                version=5),
+            transfer_teal,
             'nft_royalties/transfer.compiled')
     compile_program(
             algod_client,
             compileTeal(clear_program(), mode=Mode.Application, version=5),
             'nft_royalties/clear.compiled')
 
-    write_schema("nft_royalties/globalSchema", 1, 1)
-    write_schema("nft_royalties/localSchema", 0, 0)
+    write_schema('nft_royalties/globalSchema', 1, 2)
+    write_schema('nft_royalties/localSchema', 0, 0)
 
 
 def compile_escrow_app(algod_client, transfer_app_id):
@@ -173,6 +276,6 @@ def compile_escrow_app(algod_client, transfer_app_id):
                 mode=Mode.Signature,
                 version=5
             )
-    with open("build/nft_royalties/escrow.teal", "w") as f:
+    with open('build/nft_royalties/escrow.teal', 'w') as f:
         f.write(teal)
-    return compile_program(algod_client, teal, "nft_royalties/escrow.compiled")
+    return compile_program(algod_client, teal, 'nft_royalties/escrow.compiled')

--- a/contracts/nft_royalties/program.py
+++ b/contracts/nft_royalties/program.py
@@ -1,58 +1,48 @@
 from pyteal import *
 
-def escrow_approval():
-    # Escrow contract/account
+def transfer_approval(royalty_percent, royalty_payouts):
+    ratio_sum = sum([r["ratio"] for r in royalty_payouts])
 
-    # At the moment this is deferring to the contract whose app ID is provided
-    # for all logic, it might be a good idea to add extra precautions and
-    # requirements into this contract directly
-    on_call = Seq(
-        Assert(
-            And(
-                Txn.fee() == Int(0),
-                Gtxn[0].type_enum() == TxnType.ApplicationCall,
-                Gtxn[0].application_id() == Int(20),
-            ),
-        ),
-        Approve(),
-    )
+    indices = range(len(royalty_payouts))
 
-    on_delete = Seq(
-        Assert(Txn.sender() == Global.creator_address()),
-        Approve()
-    )
-
-    program = Cond(
-        [Txn.on_completion() == OnComplete.NoOp, on_call],
-        [Txn.on_completion() == OnComplete.DeleteApplication, on_delete],
-        [Int(1), Reject()]
-    )
-    return program
-
-
-def transfer_approval(royalties_account):
-    # Gtxn[0]
-    #     * This call
-    #     * Fee should be 0, paid by either party in transfer
-    # 
-    # Gtxn[1]
-    #     * Asset transfer via clawback, must be signed with escrow's
-    #       code
-    #     * Fee should be 0, paid by either party in transfer
-    #
-    # Gtxn[2]
-    #     * Payment for asset
-    #     * Must be going opposite direction from Gtxn[1]
-    # 
-    # Gtxn[3]
-    #     * Royalty payment
-    #     * Must be going to address specified by contract (hardcoded right now)
-    #     * Can be paid by either party(?)
-    #     * Should be at least some portion of payment (hardcoded 10% right now)
     default_frozen = AssetParam.defaultFrozen(Int(0))
     clawback = AssetParam.clawback(Int(0))
     manager = AssetParam.manager(Int(0))
     freeze = AssetParam.freeze(Int(0))
+    royalty_minimum = Gtxn[1].amount() / Int(royalty_percent) # might store in scratch?
+
+    def payRoyalty(receiver):
+        return Seq(
+            InnerTxnBuilder.Begin(),
+            InnerTxnBuilder.SetFields(
+                {
+                    TxnField.type_enum: TxnType.Payment,
+                    TxnField.receiver: Addr(receiver["address"]),
+                    TxnField.amount:
+                        royalty_minimum * Int(receiver["ratio"]) / Int(ratio_sum),
+                    TxnField.fee: Int(0),
+                }
+            ),
+            InnerTxnBuilder.Submit(),
+        )
+
+    # Gtxn[0]
+    #     * Asset transfer via clawback, must be signed with escrow's
+    #       code
+    #     * Fee should be 0, voere by either party in transfer
+    #     * Amount should be 1
+    #
+    # Gtxn[1]
+    #     * Payment for asset
+    #     * Must be going opposite direction from Gtxn[0]
+    # 
+    # Gtxn[2]
+    #     * Royalty payment
+    #     * Must be going to application account
+    #     * Can be paid by either party(?)
+    #
+    # Gtxn[3]
+    #     * This call
     on_call = Seq(
         default_frozen,
         clawback,
@@ -61,99 +51,93 @@ def transfer_approval(royalties_account):
         Assert(
             And(
                 Global.group_size() == Int(4),
-                Gtxn[0].type_enum() == TxnType.ApplicationCall,
-                Gtxn[1].type_enum() == TxnType.AssetTransfer,
+                Gtxn[0].type_enum() == TxnType.AssetTransfer,
+                Gtxn[1].type_enum() == TxnType.Payment,
                 Gtxn[2].type_enum() == TxnType.Payment,
-                Gtxn[3].type_enum() == TxnType.Payment,
+                Gtxn[3].type_enum() == TxnType.ApplicationCall,
 
-                Gtxn[1].fee() == Int(0),
-                # Since this is for NFTs, it should be transferring the one
-                # and only asset in full
-                Gtxn[1].asset_amount() == Int(1),
+                Gtxn[0].fee() == Int(0),
+                Gtxn[0].asset_amount() == Int(1),
+
+                Gtxn[0].close_remainder_to() == Global.zero_address(),
+                Gtxn[0].rekey_to() == Global.zero_address(),
+                Gtxn[1].close_remainder_to() == Global.zero_address(),
+                Gtxn[1].rekey_to() == Global.zero_address(),
+                Gtxn[2].close_remainder_to() == Global.zero_address(),
+                Gtxn[2].rekey_to() == Global.zero_address(),
+                Gtxn[3].close_remainder_to() == Global.zero_address(),
+                Gtxn[3].rekey_to() == Global.zero_address(),
+
                 default_frozen.hasValue(),
                 default_frozen.value(),
                 clawback.value() != Global.zero_address(),
                 manager.value() == Global.zero_address(),
                 freeze.value() == Global.zero_address(),
 
-                Gtxn[2].sender() == Gtxn[1].asset_receiver(),
-                Gtxn[1].asset_sender() == Gtxn[2].receiver(),
+                Gtxn[1].sender() == Gtxn[0].asset_receiver(),
+                Gtxn[0].asset_sender() == Gtxn[1].receiver(),
 
                 Or(
-                    Gtxn[3].sender() == Gtxn[1].asset_sender(),
-                    Gtxn[3].sender() == Gtxn[2].sender(),
+                    Gtxn[2].sender() == Gtxn[1].asset_sender(),
+                    Gtxn[2].sender() == Gtxn[2].sender(),
                 ),
-                Gtxn[3].receiver() == Addr(royalties_account),
+                Gtxn[2].receiver() == Global.current_application_address(),
 
-                # 10% of payment amount (plus tip!) goes to our multisig
-                Gtxn[3].amount() >= Gtxn[2].amount() / Int(10)
+                Gtxn[2].amount() >= royalty_minimum,
             )
         ),
+        Seq(*[payRoyalty(royalty_payouts[i]) for i in indices]),
         Approve()
     )
 
+    on_delete = Return(Txn.sender() == Global.creator_address())
+
     program = Cond(
         [Txn.application_id() == Int(0), Approve()],
+        [Txn.on_completion() == OnComplete.NoOp, on_call],
+        [Txn.on_completion() == OnComplete.DeleteApplication, on_delete],
+        [Int(1), Reject()]
+    )
+    return program
+
+
+def escrow_approval(transfer_app_id = 121):
+    # Escrow contract/account
+    on_call = Seq(
+        Assert(
+            And(
+                Txn.fee() == Int(0),
+                Gtxn[3].type_enum() == TxnType.ApplicationCall,
+                Gtxn[3].application_id() == Int(transfer_app_id),
+            ),
+        ),
+        Approve(),
+    )
+
+    program = Cond(
         [Txn.on_completion() == OnComplete.NoOp, on_call],
         [Int(1), Reject()]
     )
     return program
 
 
-def logicsig_approval(multisig, addresses, ratio_terms):
-    # LogicSig for spending from multisig account
-    # Can only pay out to the provided addresses in the provided ratio
-
-    assert(len(addresses) == len(ratio_terms))
-
-    ratio_sum = sum(ratio_terms)
-
-    indices = range(len(addresses))
-
-    num_parties = Int(len(addresses))
-    i = ScratchVar()
-    total_paid_out = ScratchVar()
-
-    all_payments_valid = And(
-        # Only valid after sum of payments calculated
-        total_paid_out.load() > Int(0),
-
-        # Generate checks for every party in the contract
-        And(*[
-            And(
-                Gtxn[i].type_enum() == TxnType.Payment,
-                Gtxn[i].sender() == Addr(multisig),
-                Gtxn[i].receiver() == Addr(addresses[i]),
-                Gtxn[i].amount() == total_paid_out.load() * Int(ratio_terms[i]) / Int(ratio_sum),
-            )
-            for i in indices
-        ])
-    )
-    
-    program = Seq(
-        i.store(Int(0)),
-        total_paid_out.store(Int(0)),
-        Assert(Global.group_size() == num_parties),
-        For(i.store(Int(0)), i.load() < num_parties, i.store(i.load() + Int(1)))
-        .Do(
-            total_paid_out.store(total_paid_out.load() + Gtxn[i.load()].amount()),
-        ),
-        Assert(all_payments_valid),
-        Approve()
-    )
-
-    return program
-
-
 if __name__ == "__main__":
+    royalty_percent = 10
+    royalty_payouts = [
+            {
+                "address": "ECNHJST6SMCFXH6R6Z2L4D4ZYHG6FZFULY7O3XFTXORWBRZJUF2MSQRGZA",
+                "ratio": 6
+            },
+            {
+                "address": "XFNIWS5CZ67DKPR5767PR3YIWDZFYSFNLPPEAE6YKFIMUUIZC7WGYK22IA",
+                "ratio": 4
+            },
+        ]
+
     with open("escrow.teal", "w") as f:
         compiled = compileTeal(escrow_approval(), mode=Mode.Application, version=5)
         f.write(compiled)
 
-    with open("transfer.teal", "w") as f:
-        compiled = compileTeal(transfer_approval("ES5AYWETGOE4PZKCAQJ7FF77M5NEXT5KFTCLZEMYLSZVKEY66BL45KDS2Y"), mode=Mode.Application, version=5)
-        f.write(compiled)
-
-    with open("logicsig.teal", "w") as f:
-        compiled = compileTeal(logicsig_approval("ES5AYWETGOE4PZKCAQJ7FF77M5NEXT5KFTCLZEMYLSZVKEY66BL45KDS2Y", ["ECNHJST6SMCFXH6R6Z2L4D4ZYHG6FZFULY7O3XFTXORWBRZJUF2MSQRGZA","XFNIWS5CZ67DKPR5767PR3YIWDZFYSFNLPPEAE6YKFIMUUIZC7WGYK22IA"], [60,40]), mode=Mode.Application, version=5)
+    with open("transfer_split.teal", "w") as f:
+        compiled = compileTeal(transfer_approval(royalty_percent, royalty_payouts), mode=Mode.Application, version=5)
         f.write(compiled)

--- a/contracts/nft_royalties/program.py
+++ b/contracts/nft_royalties/program.py
@@ -1,0 +1,196 @@
+from pyteal import *
+
+def escrow_approval():
+    # Escrow contract/account
+
+    # At the moment this is deferring to the contract whose app ID is provided
+    # for all logic, it might be a good idea to add extra precautions and
+    # requirements into this contract directly
+
+    # Create the logic app, this escrow, and the logicsig together
+    logic_app_id = Bytes("logic_app_id")
+    on_create = Seq(
+        Assert(
+            And(
+                Global.group_size() == Int(2),
+                Txn.group_index() == Int(1),
+
+                Gtxn[0].type_enum() == TxnType.ApplicationCall,
+                Gtxn[0].application_id() == Int(0),
+            ),
+        ),
+        App.globalPut(logic_app_id, GeneratedID(0)),
+        Approve()
+    )
+    
+    on_call = Seq(
+        Assert(
+            And(
+                Txn.fee() == Int(0),
+                Gtxn[0].type_enum() == TxnType.ApplicationCall,
+                Gtxn[0].application_id() == App.globalGet(logic_app_id),
+            ),
+        ),
+        Approve(),
+    )
+
+    on_delete = Seq(
+        Assert(Txn.sender() == Global.creator_address()),
+        Approve()
+    )
+
+    program = Cond(
+        [Txn.application_id() == Int(0), on_create],
+        [Txn.on_completion() == OnComplete.NoOp, on_call],
+        [Txn.on_completion() == OnComplete.DeleteApplication, on_delete],
+        [Int(1), Reject()]
+    )
+    return program
+
+
+def transfer_approval(royalties_account):
+    on_create = Seq(
+        Assert(
+            And(
+                Global.group_size() == Int(2),
+                Txn.group_index() == Int(0),
+
+                Gtxn[1].type_enum() == TxnType.ApplicationCall,
+                Gtxn[1].application_id() == Int(0),
+            )
+        ),
+        Approve()
+    )
+
+    # Gtxn[0]
+    #     * This call
+    #     * Fee should be 0, paid by either party in transfer
+    # 
+    # Gtxn[1]
+    #     * Asset transfer via clawback, must be signed with escrow's
+    #       code
+    #     * Fee should be 0, paid by either party in transfer
+    #
+    # Gtxn[2]
+    #     * Payment for asset
+    #     * Must be going opposite direction from Gtxn[1]
+    # 
+    # Gtxn[3]
+    #     * Royalty payment
+    #     * Must be going to address specified by contract (hardcoded right now)
+    #     * Can be paid by either party(?)
+    #     * Should be at least some portion of payment (hardcoded 10% right now)
+    default_frozen = AssetParam.defaultFrozen(Int(0))
+    clawback = AssetParam.clawback(Int(0))
+    manager = AssetParam.manager(Int(0))
+    freeze = AssetParam.freeze(Int(0))
+    on_call = Seq(
+        default_frozen,
+        clawback,
+        manager,
+        freeze,
+        Assert(
+            And(
+                Global.group_size() == Int(4),
+                Gtxn[0].type_enum() == TxnType.ApplicationCall,
+                Gtxn[1].type_enum() == TxnType.AssetTransfer,
+                Gtxn[2].type_enum() == TxnType.Payment,
+                Gtxn[3].type_enum() == TxnType.Payment,
+
+                Txn.fee() == Int(0),
+
+                Gtxn[1].fee() == Int(0),
+                # Since this is for NFTs, it should be transferring the one
+                # and only asset in full
+                Gtxn[1].asset_amount() == Int(1),
+                default_frozen.hasValue(),
+                default_frozen.value(),
+                clawback.value() != Global.zero_address(),
+                manager.value() == Global.zero_address(),
+                freeze.value() == Global.zero_address(),
+
+                Gtxn[2].sender() == Gtxn[1].receiver(),
+                Gtxn[1].sender() == Gtxn[2].receiver(),
+
+                Or(
+                    Gtxn[3].sender() == Gtxn[1].sender(),
+                    Gtxn[3].sender() == Gtxn[2].sender(),
+                ),
+                Gtxn[3].receiver() == Addr(royalties_account),
+
+                # 10% of payment amount (plus tip!) goes to our multisig
+                Gtxn[3].amount() >= Gtxn[2].amount() / Int(10)
+            )
+        ),
+        Approve()
+    )
+
+    program = Cond(
+        [Txn.application_id() == Int(0), on_create],
+        [Txn.on_completion() == OnComplete.NoOp, on_call],
+        [Int(1), Reject()]
+    )
+    return program
+
+
+def logicsig_approval(multisig, addresses, ratio_terms):
+    # LogicSig for spending from multisig account
+    # Can only pay out to the provided addresses in the provided ratio
+
+    assert(len(addresses) == len(ratio_terms))
+
+    ratio_sum = sum(ratio_terms)
+
+    def static_for_each(xs, f, wrap=Seq):
+        return [f(x) for x in xs]
+
+    indices = range(len(addresses))
+
+    num_parties = Int(len(addresses))
+    i = ScratchVar()
+    total_paid_out = ScratchVar()
+
+    all_payments_valid = And(
+        # Only valid after sum of payments calculated
+        total_paid_out.load() > Int(0),
+
+        # Generate checks for every party in the contract
+        And(*static_for_each(
+            indices,
+            lambda i:
+                And(
+                    Gtxn[i].type_enum() == TxnType.Payment,
+                    Gtxn[i].sender() == Addr(multisig),
+                    Gtxn[i].receiver() == Addr(addresses[i]),
+                    Gtxn[i].amount() == total_paid_out.load() * Int(ratio_terms[i]) / Int(ratio_sum),
+                ),
+        ))
+    )
+    
+    program = Seq(
+        i.store(Int(0)),
+        total_paid_out.store(Int(0)),
+        Assert(Global.group_size() == num_parties),
+        For(i.store(Int(0)), i.load() < num_parties, i.store(i.load() + Int(1)))
+        .Do(
+            total_paid_out.store(total_paid_out.load() + Gtxn[i.load()].amount()),
+        ),
+        Assert(all_payments_valid),
+        Approve()
+    )
+
+    return program
+
+
+if __name__ == "__main__":
+    with open("escrow.teal", "w") as f:
+        compiled = compileTeal(escrow_approval(), mode=Mode.Application, version=5)
+        f.write(compiled)
+
+    with open("transfer.teal", "w") as f:
+        compiled = compileTeal(transfer_approval("ES5AYWETGOE4PZKCAQJ7FF77M5NEXT5KFTCLZEMYLSZVKEY66BL45KDS2Y"), mode=Mode.Application, version=5)
+        f.write(compiled)
+
+    with open("logicsig.teal", "w") as f:
+        compiled = compileTeal(logicsig_approval("ES5AYWETGOE4PZKCAQJ7FF77M5NEXT5KFTCLZEMYLSZVKEY66BL45KDS2Y", ["ECNHJST6SMCFXH6R6Z2L4D4ZYHG6FZFULY7O3XFTXORWBRZJUF2MSQRGZA","XFNIWS5CZ67DKPR5767PR3YIWDZFYSFNLPPEAE6YKFIMUUIZC7WGYK22IA"], [60,40]), mode=Mode.Application, version=5)
+        f.write(compiled)

--- a/test/nft_royalties_test.py
+++ b/test/nft_royalties_test.py
@@ -74,7 +74,9 @@ class App:
                                       params,
                                       seller_address,
                                       sale.price)
-        txn1.fee = 4000 + 1000 * len(self.royalty_payouts)
+        txn1.fee = 4000
+        if sale.royalty_permille > 0:
+            txn1.fee += 1000 * len(self.royalty_payouts)
         txn2 = transaction.PaymentTxn(buyer_address,
                                       params,
                                       self.address,
@@ -313,18 +315,18 @@ class TestNFTRoyalties:
 
 
     def test_sell(self, client, app, wallet_1, wallet_2):
-        app.perform_sale(client, Sale(wallet_1, wallet_2, 1000000, 100))
+        app.perform_sale(client, Sale(wallet_1, wallet_2, 1500000, 100))
 
 
     def test_insufficient_royalty(self, client, app, wallet_1, wallet_2):
         with pytest.raises(AlgodHTTPError):
             # Should fail before we decrease the minimum royalty
-            app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 50))
+            app.perform_sale(client, Sale(wallet_2, wallet_1, 2500000, 50))
 
 
     def test_reduce_royalty(self, client, app, wallet_1, wallet_2):
         app.set_royalty(client, 40)
-        app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 50))
+        app.perform_sale(client, Sale(wallet_2, wallet_1, 2500000, 60))
 
     
     def test_no_authority(self, client, app, creator, wallet_1, wallet_2):

--- a/test/nft_royalties_test.py
+++ b/test/nft_royalties_test.py
@@ -1,0 +1,302 @@
+import pytest
+from algosdk.v2client import algod
+from algosdk import account, mnemonic, constants, encoding
+from algosdk.encoding import encode_address, is_valid_address
+from algosdk.error import AlgodHTTPError, TemplateInputError
+from akita_inu_asa_utils import read_local_state, read_global_state, wait_for_txn_confirmation, load_compiled
+import base64
+
+
+class App:
+    __slots__ = ('id',
+                 'creator',
+                 'address',
+                 'escrow_address',
+                 'escrow_program',
+                 'asset_id',
+                 'royalty_receivers'
+                )
+
+
+    def __init__(self, test_config, asset_id, creator, royalty_receivers):
+        from contracts.nft_royalties.deployment import deploy
+
+        algod_address = test_config['algodAddress']
+        algod_token = test_config['algodToken']
+        creator_mnemonic = creator['mnemonic']
+        clear_build_folder()
+
+        royalty_percent = 10
+        royalty_payouts = [
+                {
+                    "address": royalty_receivers[0],
+                    "ratio": 60
+                },
+                {
+                    "address": royalty_receivers[1],
+                    "ratio": 40
+                },
+            ]
+
+        app_details = deploy(algod_address,
+                             algod_token,
+                             creator_mnemonic,
+                             asset_id,
+                             royalty_percent,
+                             royalty_payouts)
+        
+        self.asset_id = asset_id
+        self.creator = creator
+        self.id = app_details[0]
+        self.escrow_address = app_details[1]
+        self.address = encode_address(encoding.checksum(b'appID' + self.id.to_bytes(8, 'big')))
+        self.escrow_program = load_compiled(file_path='nft_royalties/escrow.compiled')
+        self.royalty_receivers = royalty_receivers
+
+
+    def perform_sale(self, client, sale):
+        from algosdk.future import transaction
+        params = client.suggested_params()
+        buyer_address = sale.buyer["public_key"]
+        seller_address = sale.seller["public_key"]
+        buyer_key = sale.buyer["private_key"]
+        seller_key = sale.seller["private_key"]
+        txn0 = transaction.AssetTransferTxn(self.escrow_address,
+                                            params,
+                                            buyer_address,
+                                            1,
+                                            self.asset_id,
+                                            revocation_target=seller_address)
+        txn0.fee = 0
+        txn1 = transaction.PaymentTxn(buyer_address,
+                                      params,
+                                      seller_address,
+                                      sale.price)
+        txn1.fee = 6000
+        txn2 = transaction.PaymentTxn(buyer_address,
+                                      params,
+                                      self.address,
+                                      int(sale.price / (100 / sale.royalty_percent)))
+        txn2.fee = 0
+        txn3 = transaction.ApplicationCallTxn(seller_address,
+                                              params,
+                                              self.id,
+                                              transaction.OnComplete.NoOpOC.real,
+                                              foreign_assets=[self.asset_id],
+                                              accounts=self.royalty_receivers)
+        
+        logic_sig = transaction.LogicSigAccount(self.escrow_program)
+        grouped = transaction.assign_group_id([txn0, txn1, txn2, txn3])
+        grouped = [transaction.LogicSigTransaction(grouped[0], logic_sig),
+                   grouped[1].sign(buyer_key),
+                   grouped[2].sign(buyer_key),
+                   grouped[3].sign(seller_key)]
+
+        txn_id = client.send_transactions(grouped)
+        wait_for_txn_confirmation(client, txn_id, 5)
+
+
+    def perform_unauthed_sale(self, client, sale):
+        # Previous version allowed sales of this sort, performed without
+        # any input from the seller/asset owner
+        from algosdk.future import transaction
+        params = client.suggested_params()
+        buyer_address = sale.buyer["public_key"]
+        seller_address = sale.seller["public_key"]
+        buyer_key = sale.buyer["private_key"]
+        seller_key = sale.seller["private_key"]
+        txn0 = transaction.AssetTransferTxn(self.escrow_address,
+                                            params,
+                                            buyer_address,
+                                            1,
+                                            self.asset_id,
+                                            revocation_target=seller_address)
+        txn0.fee = 0
+        txn1 = transaction.PaymentTxn(buyer_address,
+                                      params,
+                                      seller_address,
+                                      sale.price)
+        txn1.fee = 4000 + 1000 * len(self.royalty_receivers)
+        txn2 = transaction.PaymentTxn(buyer_address,
+                                      params,
+                                      self.address,
+                                      int(sale.price / (100 / sale.royalty_percent)))
+        txn2.fee = 0
+        txn3 = transaction.ApplicationCallTxn(buyer_address,
+                                              params,
+                                              self.id,
+                                              transaction.OnComplete.NoOpOC.real,
+                                              foreign_assets=[self.asset_id],
+                                              accounts=self.royalty_receivers)
+        
+        logic_sig = transaction.LogicSigAccount(self.escrow_program)
+        grouped = transaction.assign_group_id([txn0, txn1, txn2, txn3])
+        grouped = [transaction.LogicSigTransaction(grouped[0], logic_sig),
+                   grouped[1].sign(buyer_key),
+                   grouped[2].sign(buyer_key),
+                   grouped[3].sign(buyer_key)]
+
+        txn_id = client.send_transactions(grouped)
+        wait_for_txn_confirmation(client, txn_id, 5)
+
+
+    def delete(self, client):
+        from algosdk.future import transaction
+        params = client.suggested_params()
+        txn = transaction.ApplicationDeleteTxn(self.creator['public_key'],
+                                               params,
+                                               self.id)
+        client.send_transaction(txn.sign(self.creator['private_key']))
+    
+
+class Sale:
+    __slots__ = 'seller', 'buyer', 'price', 'royalty_percent'
+
+    def __init__(self, seller, buyer, price, royalty_percent=10):
+        self.seller = seller
+        self.buyer = buyer
+        self.price = price
+        self.royalty_percent = royalty_percent
+
+
+@pytest.fixture(scope='class')
+def test_config():
+    from .testing_utils import load_test_config
+    return load_test_config()
+
+
+@pytest.fixture(scope='class')
+def client(test_config):
+    algod_address = test_config['algodAddress']
+    algod_token = test_config['algodToken']
+    client = algod.AlgodClient(algod_token, algod_address)
+    return client
+
+
+def new_wallet(client, funding_account=None, opt_in_asset=None):
+    from algosdk.future import transaction
+    from akita_inu_asa_utils import generate_new_account
+    from .testing_utils import fund_account
+    wallet_mnemonic, private_key, public_key = generate_new_account()
+
+    wallet = {'mnemonic': wallet_mnemonic, 'public_key': public_key, 'private_key': private_key}
+
+    if funding_account:
+        fund_account(wallet['public_key'], funding_account)
+
+    if opt_in_asset:
+        params = client.suggested_params()
+        optin = transaction.AssetOptInTxn(wallet["public_key"],
+                                          params,
+                                          opt_in_asset)
+        client.send_transaction(optin.sign(wallet["private_key"]))
+
+    return wallet
+
+
+@pytest.fixture(scope='class')
+def creator(test_config):
+    return new_wallet(client, test_config['fund_account_mnemonic'])
+
+
+@pytest.fixture(scope='class')
+def wallet_1(test_config, asset_id, client):
+    return new_wallet(client, test_config['fund_account_mnemonic'], asset_id)
+
+
+@pytest.fixture(scope='class')
+def wallet_2(test_config, asset_id, client):
+    return new_wallet(client, test_config['fund_account_mnemonic'], asset_id)
+
+
+@pytest.fixture(scope='class')
+def asset_id(test_config, creator, client):
+    from akita_inu_asa_utils import( create_asa_signed_txn,
+        asset_id_from_create_txn)
+    params = client.suggested_params()
+    txn, txn_id = create_asa_signed_txn(creator['public_key'],
+                                        creator['private_key'],
+                                        params,
+                                        default_frozen=True,
+                                        total=1)
+    client.send_transactions([txn])
+    wait_for_txn_confirmation(client, txn_id, 5)
+    return asset_id_from_create_txn(client, txn_id)
+
+
+@pytest.fixture(scope='class')
+def royalty_receivers(test_config, creator):
+    return [test_config["fund_account_public_key"], creator["public_key"]]
+
+
+@pytest.fixture(scope='class')
+def app(test_config, asset_id, creator, royalty_receivers):
+    return App(test_config, asset_id, creator, royalty_receivers)
+
+
+def clear_build_folder():
+    import os
+    for file in os.scandir('./build/nft_royalties'):
+        os.remove(file.path)
+
+
+def fund_accounts(client, creator, app):
+    from algosdk.future import transaction
+    params = client.suggested_params()
+    txn = transaction.PaymentTxn(creator["public_key"],
+                                 params,
+                                 app.address,
+                                 100000)
+    signed_txn = txn.sign(creator["private_key"])
+    txn_id = client.send_transaction(signed_txn)
+
+    txn = transaction.PaymentTxn(creator["public_key"],
+                                 params,
+                                 app.escrow_address,
+                                 100000)
+    signed_txn = txn.sign(creator["private_key"])
+    txn_id = client.send_transaction(signed_txn)
+
+    
+class TestNFTRoyalties:
+    def test_build(self, app):
+        import os
+        assert os.path.exists('./build/nft_royalties/transfer.compiled')
+        assert os.path.exists('./build/nft_royalties/clear.compiled')
+        assert os.path.exists('./build/nft_royalties/escrow.teal')
+        assert os.path.exists('./build/nft_royalties/escrow.compiled')
+        assert os.path.exists('./build/nft_royalties/globalSchema')
+        assert os.path.exists('./build/nft_royalties/localSchema')
+
+
+    def test_distribute(self, client, app, creator, wallet_1):
+        assert app.asset_id
+        assert app.id
+        fund_accounts(client, creator, app)
+        app.perform_sale(client, Sale(creator, wallet_1, 0, 10))
+
+
+    def test_sell(self, client, app, wallet_1, wallet_2):
+        app.perform_sale(client, Sale(wallet_1, wallet_2, 1000000, 10))
+
+    
+    def test_no_authority(self, client, app, wallet_1, wallet_2):
+        with pytest.raises(AlgodHTTPError):
+            app.perform_unauthed_sale(client, Sale(wallet_2, wallet_1, 0, 10))
+
+
+    def test_insufficient_royalty(self, client, app, wallet_1, wallet_2):
+        assert asset_id
+        assert app.id
+        with pytest.raises(AlgodHTTPError):
+            app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 5))
+        app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 10))
+
+
+    def test_delete_app(self, client, app, wallet_1, creator):
+        with pytest.raises(AlgodHTTPError):
+            # We want delete to fail if the creator doesn't hold the NFT
+            app.delete(client)
+        app.perform_sale(client, Sale(wallet_1, creator, 0, 10))
+        app.delete(client)
+

--- a/test/nft_royalties_test.py
+++ b/test/nft_royalties_test.py
@@ -1,7 +1,8 @@
 import pytest
 from algosdk.v2client import algod
 from algosdk import account, mnemonic, constants, encoding
-from algosdk.encoding import encode_address, is_valid_address
+from algosdk.future import transaction
+from algosdk.encoding import encode_address, decode_address, is_valid_address
 from algosdk.error import AlgodHTTPError, TemplateInputError
 from akita_inu_asa_utils import read_local_state, read_global_state, wait_for_txn_confirmation, load_compiled
 import base64
@@ -11,10 +12,10 @@ class App:
     __slots__ = ('id',
                  'creator',
                  'address',
-                 'escrow_address',
-                 'escrow_program',
                  'asset_id',
-                 'royalty_receivers'
+                 'royalty_permille',
+                 'royalty_payouts',
+                 'logic_sig'
                 )
 
 
@@ -26,15 +27,15 @@ class App:
         creator_mnemonic = creator['mnemonic']
         clear_build_folder()
 
-        royalty_percent = 10
-        royalty_payouts = [
+        self.royalty_permille = 100
+        self.royalty_payouts = [
                 {
-                    "address": royalty_receivers[0],
-                    "ratio": 60
+                    'address': royalty_receivers[0],
+                    'ratio': 60
                 },
                 {
-                    "address": royalty_receivers[1],
-                    "ratio": 40
+                    'address': royalty_receivers[1],
+                    'ratio': 40
                 },
             ]
 
@@ -42,26 +43,27 @@ class App:
                              algod_token,
                              creator_mnemonic,
                              asset_id,
-                             royalty_percent,
-                             royalty_payouts)
+                             self.royalty_permille,
+                             self.royalty_payouts)
         
         self.asset_id = asset_id
         self.creator = creator
         self.id = app_details[0]
-        self.escrow_address = app_details[1]
+        escrow_address = app_details[1]
         self.address = encode_address(encoding.checksum(b'appID' + self.id.to_bytes(8, 'big')))
-        self.escrow_program = load_compiled(file_path='nft_royalties/escrow.compiled')
-        self.royalty_receivers = royalty_receivers
+
+        escrow_program = load_compiled(file_path='nft_royalties/escrow.compiled')
+        self.logic_sig = transaction.LogicSigAccount(escrow_program)
+        assert escrow_address == self.logic_sig.address()
 
 
-    def perform_sale(self, client, sale):
-        from algosdk.future import transaction
+    def perform_sale(self, client, sale, authed=True):
         params = client.suggested_params()
-        buyer_address = sale.buyer["public_key"]
-        seller_address = sale.seller["public_key"]
-        buyer_key = sale.buyer["private_key"]
-        seller_key = sale.seller["private_key"]
-        txn0 = transaction.AssetTransferTxn(self.escrow_address,
+        buyer_address = sale.buyer['public_key']
+        seller_address = sale.seller['public_key']
+        buyer_key = sale.buyer['private_key']
+        seller_key = sale.seller['private_key']
+        txn0 = transaction.AssetTransferTxn(self.logic_sig.address(),
                                             params,
                                             buyer_address,
                                             1,
@@ -72,91 +74,127 @@ class App:
                                       params,
                                       seller_address,
                                       sale.price)
-        txn1.fee = 6000
+        txn1.fee = 4000 + 1000 * len(self.royalty_payouts)
         txn2 = transaction.PaymentTxn(buyer_address,
                                       params,
                                       self.address,
-                                      int(sale.price / (100 / sale.royalty_percent)))
+                                      int(sale.price * sale.royalty_permille / 1000))
         txn2.fee = 0
         txn3 = transaction.ApplicationCallTxn(seller_address,
                                               params,
                                               self.id,
                                               transaction.OnComplete.NoOpOC.real,
                                               foreign_assets=[self.asset_id],
-                                              accounts=self.royalty_receivers)
+                                              app_args=['transfer'],
+                                              accounts=[r['address']
+                                                        for r in self.royalty_payouts])
+        txn3.fee = 0
         
-        logic_sig = transaction.LogicSigAccount(self.escrow_program)
         grouped = transaction.assign_group_id([txn0, txn1, txn2, txn3])
-        grouped = [transaction.LogicSigTransaction(grouped[0], logic_sig),
+        grouped = [transaction.LogicSigTransaction(grouped[0], self.logic_sig),
                    grouped[1].sign(buyer_key),
                    grouped[2].sign(buyer_key),
-                   grouped[3].sign(seller_key)]
+                   grouped[3].sign(seller_key if authed else buyer_key)]
 
         txn_id = client.send_transactions(grouped)
         wait_for_txn_confirmation(client, txn_id, 5)
 
 
-    def perform_unauthed_sale(self, client, sale):
-        # Previous version allowed sales of this sort, performed without
-        # any input from the seller/asset owner
-        from algosdk.future import transaction
+    def reconfigure_asset(self, client):
         params = client.suggested_params()
-        buyer_address = sale.buyer["public_key"]
-        seller_address = sale.seller["public_key"]
-        buyer_key = sale.buyer["private_key"]
-        seller_key = sale.seller["private_key"]
-        txn0 = transaction.AssetTransferTxn(self.escrow_address,
-                                            params,
-                                            buyer_address,
-                                            1,
-                                            self.asset_id,
-                                            revocation_target=seller_address)
+        txn0 = transaction.AssetConfigTxn(self.logic_sig.address(),
+                                          params,
+                                          index=self.asset_id,
+                                          strict_empty_address_check=False,
+                                          manager=self.logic_sig.address(),
+                                          freeze=self.logic_sig.address(),
+                                          clawback=self.logic_sig.address(),
+                                         )
         txn0.fee = 0
-        txn1 = transaction.PaymentTxn(buyer_address,
-                                      params,
-                                      seller_address,
-                                      sale.price)
-        txn1.fee = 4000 + 1000 * len(self.royalty_receivers)
-        txn2 = transaction.PaymentTxn(buyer_address,
-                                      params,
-                                      self.address,
-                                      int(sale.price / (100 / sale.royalty_percent)))
-        txn2.fee = 0
-        txn3 = transaction.ApplicationCallTxn(buyer_address,
-                                              params,
-                                              self.id,
-                                              transaction.OnComplete.NoOpOC.real,
-                                              foreign_assets=[self.asset_id],
-                                              accounts=self.royalty_receivers)
-        
-        logic_sig = transaction.LogicSigAccount(self.escrow_program)
-        grouped = transaction.assign_group_id([txn0, txn1, txn2, txn3])
-        grouped = [transaction.LogicSigTransaction(grouped[0], logic_sig),
-                   grouped[1].sign(buyer_key),
-                   grouped[2].sign(buyer_key),
-                   grouped[3].sign(buyer_key)]
+        txn1 = transaction.ApplicationDeleteTxn(self.creator['public_key'],
+                                                params,
+                                                self.id)
+        txn1.fee = 2000
+        grouped = transaction.assign_group_id([txn0, txn1])
+        grouped = [transaction.LogicSigTransaction(grouped[0], self.logic_sig),
+                   grouped[1].sign(self.creator['private_key'])]
+        client.send_transactions(grouped)
+    
+    
+    def set_royalty(self, client, royalty_permille):
+        params = client.suggested_params()
+        txn = transaction.ApplicationCallTxn(self.creator['public_key'],
+                                             params,
+                                             self.id,
+                                             transaction.OnComplete.NoOpOC.real,
+                                             app_args=['set_royalty',
+                                                       royalty_permille],
+                                             foreign_assets=[self.asset_id],
+                                             )
+        client.send_transaction(txn.sign(self.creator['private_key']))
 
-        txn_id = client.send_transactions(grouped)
-        wait_for_txn_confirmation(client, txn_id, 5)
+
+    def delete_without_destroy(self, client):
+        params = client.suggested_params()
+        txn0 = transaction.PaymentTxn(self.logic_sig.address(),
+                                      params,
+                                      self.creator['public_key'],
+                                      0,
+                                      close_remainder_to=self.creator['public_key'])
+        txn0.fee = 0
+        txn1 = transaction.ApplicationDeleteTxn(self.creator['public_key'],
+                                                params,
+                                                self.id,
+                                                foreign_assets=[self.asset_id])
+        txn1.fee = 3000
+        grouped = transaction.assign_group_id([txn0, txn1])
+        grouped = [transaction.LogicSigTransaction(grouped[0], self.logic_sig),
+                   grouped[1].sign(self.creator['private_key'])]
+        client.send_transactions(grouped)
+
+
+    def destroy_without_delete(self, client):
+        # Really should never succeed, since the escrow requires a txn fee of
+        # 0 and a valid call to the application, but just in case
+        params = client.suggested_params()
+        txn = transaction.AssetDestroyTxn(self.logic_sig.address(),
+                                          params,
+                                          self.asset_id)
+        client.send_transaction(transaction.LogicSigTransaction(txn, self.logic_sig))
 
 
     def delete(self, client):
-        from algosdk.future import transaction
         params = client.suggested_params()
-        txn = transaction.ApplicationDeleteTxn(self.creator['public_key'],
-                                               params,
-                                               self.id)
-        client.send_transaction(txn.sign(self.creator['private_key']))
-    
+        txn0 = transaction.AssetDestroyTxn(self.logic_sig.address(),
+                                           params,
+                                           self.asset_id)
+        txn0.fee = 0
+        txn1 = transaction.PaymentTxn(self.logic_sig.address(),
+                                      params,
+                                      self.creator['public_key'],
+                                      0,
+                                      close_remainder_to=self.creator['public_key'])
+        txn1.fee = 0
+        txn2 = transaction.ApplicationDeleteTxn(self.creator['public_key'],
+                                                params,
+                                                self.id,
+                                                foreign_assets=[self.asset_id])
+        txn2.fee = 3000
+        grouped = transaction.assign_group_id([txn0, txn1, txn2])
+        grouped = [transaction.LogicSigTransaction(grouped[0], self.logic_sig),
+                   transaction.LogicSigTransaction(grouped[1], self.logic_sig),
+                   grouped[2].sign(self.creator['private_key'])]
+        client.send_transactions(grouped)
+
 
 class Sale:
-    __slots__ = 'seller', 'buyer', 'price', 'royalty_percent'
+    __slots__ = 'seller', 'buyer', 'price', 'royalty_permille'
 
-    def __init__(self, seller, buyer, price, royalty_percent=10):
+    def __init__(self, seller, buyer, price, royalty_permille=100):
         self.seller = seller
         self.buyer = buyer
         self.price = price
-        self.royalty_percent = royalty_percent
+        self.royalty_permille = royalty_permille
 
 
 @pytest.fixture(scope='class')
@@ -174,7 +212,6 @@ def client(test_config):
 
 
 def new_wallet(client, funding_account=None, opt_in_asset=None):
-    from algosdk.future import transaction
     from akita_inu_asa_utils import generate_new_account
     from .testing_utils import fund_account
     wallet_mnemonic, private_key, public_key = generate_new_account()
@@ -186,10 +223,10 @@ def new_wallet(client, funding_account=None, opt_in_asset=None):
 
     if opt_in_asset:
         params = client.suggested_params()
-        optin = transaction.AssetOptInTxn(wallet["public_key"],
+        optin = transaction.AssetOptInTxn(wallet['public_key'],
                                           params,
                                           opt_in_asset)
-        client.send_transaction(optin.sign(wallet["private_key"]))
+        client.send_transaction(optin.sign(wallet['private_key']))
 
     return wallet
 
@@ -226,7 +263,7 @@ def asset_id(test_config, creator, client):
 
 @pytest.fixture(scope='class')
 def royalty_receivers(test_config, creator):
-    return [test_config["fund_account_public_key"], creator["public_key"]]
+    return [test_config['fund_account_public_key'], creator['public_key']]
 
 
 @pytest.fixture(scope='class')
@@ -241,23 +278,22 @@ def clear_build_folder():
 
 
 def fund_accounts(client, creator, app):
-    from algosdk.future import transaction
     params = client.suggested_params()
-    txn = transaction.PaymentTxn(creator["public_key"],
+    txn = transaction.PaymentTxn(creator['public_key'],
                                  params,
                                  app.address,
                                  100000)
-    signed_txn = txn.sign(creator["private_key"])
+    signed_txn = txn.sign(creator['private_key'])
     txn_id = client.send_transaction(signed_txn)
 
-    txn = transaction.PaymentTxn(creator["public_key"],
+    txn = transaction.PaymentTxn(creator['public_key'],
                                  params,
-                                 app.escrow_address,
+                                 app.logic_sig.address(),
                                  100000)
-    signed_txn = txn.sign(creator["private_key"])
+    signed_txn = txn.sign(creator['private_key'])
     txn_id = client.send_transaction(signed_txn)
 
-    
+
 class TestNFTRoyalties:
     def test_build(self, app):
         import os
@@ -273,30 +309,52 @@ class TestNFTRoyalties:
         assert app.asset_id
         assert app.id
         fund_accounts(client, creator, app)
-        app.perform_sale(client, Sale(creator, wallet_1, 0, 10))
+        app.perform_sale(client, Sale(creator, wallet_1, 0, 0))
 
 
     def test_sell(self, client, app, wallet_1, wallet_2):
-        app.perform_sale(client, Sale(wallet_1, wallet_2, 1000000, 10))
-
-    
-    def test_no_authority(self, client, app, wallet_1, wallet_2):
-        with pytest.raises(AlgodHTTPError):
-            app.perform_unauthed_sale(client, Sale(wallet_2, wallet_1, 0, 10))
+        app.perform_sale(client, Sale(wallet_1, wallet_2, 1000000, 100))
 
 
     def test_insufficient_royalty(self, client, app, wallet_1, wallet_2):
-        assert asset_id
-        assert app.id
         with pytest.raises(AlgodHTTPError):
-            app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 5))
-        app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 10))
+            # Should fail before we decrease the minimum royalty
+            app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 50))
+
+
+    def test_reduce_royalty(self, client, app, wallet_1, wallet_2):
+        app.set_royalty(client, 40)
+        app.perform_sale(client, Sale(wallet_2, wallet_1, 10000, 50))
+
+    
+    def test_no_authority(self, client, app, creator, wallet_1, wallet_2):
+        with pytest.raises(AlgodHTTPError):
+            app.perform_sale(client, Sale(wallet_1, wallet_2, 0, 0), authed=False)
+        with pytest.raises(AlgodHTTPError):
+            app.perform_sale(client, Sale(creator, wallet_2, 0, 0))
+
+
+    def test_reconfigure(self, client, app):
+        with pytest.raises(AlgodHTTPError):
+            app.reconfigure_asset(client)
+
+
+    def test_not_holding(self, client, app):
+        # All the manager calls that should fail when not holding our NFT
+        with pytest.raises(AlgodHTTPError):
+            app.delete(client)
+        with pytest.raises(AlgodHTTPError):
+            app.set_royalty(client, 100)
 
 
     def test_delete_app(self, client, app, wallet_1, creator):
-        with pytest.raises(AlgodHTTPError):
-            # We want delete to fail if the creator doesn't hold the NFT
-            app.delete(client)
-        app.perform_sale(client, Sale(wallet_1, creator, 0, 10))
-        app.delete(client)
+        app.perform_sale(client, Sale(wallet_1, creator, 0, 0))
+        app.set_royalty(client, 100)
 
+        # Should only be able to delete the app and destroy the asset together
+        with pytest.raises(AlgodHTTPError):
+            app.delete_without_destroy(client)
+        with pytest.raises(AlgodHTTPError):
+            app.destroy_without_delete(client)
+
+        app.delete(client)

--- a/test/timed_asset_lock_contract_test.py
+++ b/test/timed_asset_lock_contract_test.py
@@ -51,7 +51,9 @@ def wallet_2(test_config, asset_id, client):
     fund_account(wallet_2['public_key'], test_config['fund_account_mnemonic'])
 
     params = client.suggested_params()
-    opt_in_asset_signed_txn(private_key, public_key, params, asset_id)
+    txn, txn_id = opt_in_asset_signed_txn(private_key, public_key, params, asset_id)
+    client.send_transactions([txn])
+    wait_for_txn_confirmation(client, txn_id, 5)
     return wallet_2
 
 


### PR DESCRIPTION
I think this code should be a good starting point for functioning royalty payments.

I've chosen to generate a lot of the TEAL logic statically, by passing arguments in Python, rather than have checks and management code on-chain. I think this makes for a cleaner process with a smaller attack surface, but it reduces flexibility of the contract. The app does accept updates from the manager address if their account also holds the NFT, so any problems that might arise from this can still be corrected in future with the NFT owner's consent.

It would be worth trying to construct a valid atomic transaction that doesn't fit the structure defined in [transfer_approval()](https://github.com/soimec/SmartContracts/blob/nft_royalties/contracts/nft_royalties/program.py#L5). Note that the program as is actually has no reference to the escrow program or account, which should be hardcoded with the app ID and validated by the asset creator (see [deployment code](https://github.com/soimec/SmartContracts/blob/nft_royalties/contracts/nft_royalties/deployment.py#L69-L87) for example). Based only on the code in the program, a call to the application with another escrow account/program would be approved, but the transaction would be expected to fail on the network since the account doesn't have the authority to perform a clawback or asset config transaction. I think this would be the main thing to consider when writing tests or adding new calls to the program in future.