### PR TITLE
fixed erroneous tests (Issue # 53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/*
 __pycache__
 /__pycache__/*
 test/.secrets
+.vscode

--- a/akita_inu_asa_utils.py
+++ b/akita_inu_asa_utils.py
@@ -108,16 +108,6 @@ def pretty_print_state(state):
     print("\n\n\n")
 
 
-def get_key_from_state(state, key):
-    for i in range(0, len(state)):
-        found_key = base64.b64decode(state[i]['key'])
-        if found_key == key:
-            if state[i]['value']['type'] == 1:
-                return base64.b64decode(state[i]['value']['bytes'])
-            elif state[i]['value']['type'] == 2:
-                return state[i]['value']['uint']
-
-
 def dump_teal_assembly(file_path, program_fn_pointer):
     check_build_dir()
     with open('build/' + file_path, 'w') as f:

--- a/test/asa_faucet_test.py
+++ b/test/asa_faucet_test.py
@@ -7,7 +7,7 @@ from algosdk.future import transaction
 from algosdk import account, mnemonic, constants
 from algosdk.encoding import encode_address, is_valid_address
 from algosdk.error import AlgodHTTPError, TemplateInputError
-from akita_inu_asa_utils import read_local_state, read_global_state, wait_for_txn_confirmation, get_key_from_state
+from akita_inu_asa_utils import read_local_state, read_global_state, wait_for_txn_confirmation
 from .testing_utils import clear_build_folder
 
 NUM_TEST_ASSET = int(1e6)
@@ -90,10 +90,10 @@ class TestASAFaucet:
         public_key = wallet_1['public_key']
 
         global_state = read_global_state(client, public_key, app_id)
-        assert get_key_from_state(global_state, b'asset_id_key') == asset_id
-        assert get_key_from_state(global_state, b'drip_time') == DRIP_TIME_SEC
-        assert get_key_from_state(global_state, b'min_algo_amount') == MIN_ALGO_AMOUNT
-        assert get_key_from_state(global_state, b'min_asset_amount') == MIN_ASA_AMOUNT
+        assert global_state['asset_id_key'] == asset_id
+        assert global_state['drip_time'] == DRIP_TIME_SEC
+        assert global_state['min_algo_amount'] == MIN_ALGO_AMOUNT
+        assert global_state['min_asset_amount'] == MIN_ASA_AMOUNT
 
     def test_opt_in(self, app_id, client, asset_id, wallet_1):
         from akita_inu_asa_utils import opt_in_app_signed_txn, wait_for_txn_confirmation
@@ -105,7 +105,7 @@ class TestASAFaucet:
         wait_for_txn_confirmation(client, txn_id, 5)
 
         local_state = read_local_state(client, public_key, app_id)
-        assert time.time() - 60 <= get_key_from_state(local_state, b'user_last_claim_time') <= time.time()
+        assert time.time() - 60 <= local_state['user_last_claim_time'] <= time.time()
 
     def test_opt_in_asset(self, app_id, client, asset_id, wallet_1):
         from akita_inu_asa_utils import get_application_address
@@ -171,7 +171,7 @@ class TestASAFaucet:
 
         local_state = read_local_state(client, public_key, app_id)
         assert get_asset_balance(client, public_key, asset_id) == wallet_balance_pre + DRIP_AMOUNT
-        assert get_key_from_state(local_state, b'user_last_claim_time') <= (time.time() + 15)
+        assert local_state['user_last_claim_time'] <= (time.time() + 15)
 
     def test_claim_to_soon(self, app_id, client, asset_id, wallet_1):
         from akita_inu_asa_utils import get_application_address


### PR DESCRIPTION
Issue #53: Tests 2, 3, and 6 in asa_faucet_test.py give error: "KeyError: 0"

This pull request fixes it so all tests pass.

### Changes
* Change all calls from: 
```
get_key_from_state(state, b'key_name')
```
to:
```
state['key_name']
```
* Remove the get_key_from_state() from akita_inu_asa_utils.py as no other tests call the function.

### Possible problems
The original function iterated over the state array, decoding a b64 key stored in state and then made sure to match the decoded string against the given key. The error is either that there is no [i] element to iterate over, or there is no ['key'] element. I attempted to lookup the nature of the state key-pairs but  AlgodClient.account_info (from the sdk docs) just says "returns account information." Either way, the proposed change appears to fix it.

I'm not sure if removing it has bigger implications, but so far tests are green with the proposed change. 